### PR TITLE
Improve fp6 and fp12 arithmetics return type

### DIFF
--- a/scripts/fp12.py
+++ b/scripts/fp12.py
@@ -1,96 +1,96 @@
 import montgomery as monty
 import fp6
 
-FP6_ZERO = [0,0,0,0,0,0]
+FP6_ZERO = (0,0,0,0,0,0)
 FP6_ONE = [monty.ONE] + [0 for _ in range(5)]
 
 # Algorithm 18 from https://eprint.iacr.org/2010/354.pdf
 def add(a_000, a_001, a_010, a_011, a_020, a_021, a_100, a_101, a_110, a_111, a_120, a_121, b_000, b_001, b_010, b_011, b_020, b_021, b_100, b_101, b_110, b_111, b_120, b_121):
     c0 = fp6.add(a_000, a_001, a_010, a_011, a_020, a_021, b_000, b_001, b_010, b_011, b_020, b_021)
     c1 = fp6.add(a_100, a_101, a_110, a_111, a_120, a_121, b_100, b_101, b_110, b_111, b_120, b_121)
-    return c0, c1
+    return c0 + c1
 
 # Algorithm 19 from https://eprint.iacr.org/2010/354.pdf
 def sub(a_000, a_001, a_010, a_011, a_020, a_021, a_100, a_101, a_110, a_111, a_120, a_121, b_000, b_001, b_010, b_011, b_020, b_021, b_100, b_101, b_110, b_111, b_120, b_121):
     c0 = fp6.sub(a_000, a_001, a_010, a_011, a_020, a_021, b_000, b_001, b_010, b_011, b_020, b_021)
     c1 = fp6.sub(a_100, a_101, a_110, a_111, a_120, a_121, b_100, b_101, b_110, b_111, b_120, b_121)
-    return c0, c1
+    return c0 + c1
 
 # Algorithm 20 from https://eprint.iacr.org/2010/354.pdf
 def mul(a_000, a_001, a_010, a_011, a_020, a_021, a_100, a_101, a_110, a_111, a_120, a_121, b_000, b_001, b_010, b_011, b_020, b_021, b_100, b_101, b_110, b_111, b_120, b_121):
     t0 = fp6.mul(a_000, a_001, a_010, a_011, a_020, a_021, b_000, b_001, b_010, b_011, b_020, b_021)
     t1 = fp6.mul(a_100, a_101, a_110, a_111, a_120, a_121, b_100, b_101, b_110, b_111, b_120, b_121)
-    t2 = fp6.mul_by_gamma(t1[0][0],t1[0][1],t1[1][0],t1[1][1],t1[2][0],t1[2][1])
-    c0 = fp6.add(t0[0][0],t0[0][1],t0[1][0],t0[1][1],t0[2][0],t0[2][1],t2[0][0],t2[0][1],t2[1][0],t2[1][1],t2[2][0],t2[2][1])
+    t2 = fp6.mul_by_gamma(*t1)
+    c0 = fp6.add(*t0,*t2)
     t3 = fp6.add(a_000, a_001, a_010, a_011, a_020, a_021, a_100, a_101, a_110, a_111, a_120, a_121)
     t4 = fp6.add(b_000, b_001, b_010, b_011, b_020, b_021, b_100, b_101, b_110, b_111, b_120, b_121)
-    c1 = fp6.mul(t3[0][0],t3[0][1],t3[1][0],t3[1][1],t3[2][0],t3[2][1],t4[0][0],t4[0][1],t4[1][0],t4[1][1],t4[2][0],t4[2][1])
-    c1 = fp6.sub(c1[0][0],c1[0][1],c1[1][0],c1[1][1],c1[2][0],c1[2][1],t0[0][0],t0[0][1],t0[1][0],t0[1][1],t0[2][0],t0[2][1])
-    c1 = fp6.sub(c1[0][0],c1[0][1],c1[1][0],c1[1][1],c1[2][0],c1[2][1],t1[0][0],t1[0][1],t1[1][0],t1[1][1],t1[2][0],t1[2][1])
-    return c0, c1
+    c1 = fp6.mul(*t3,*t4)
+    c1 = fp6.sub(*c1,*t0)
+    c1 = fp6.sub(*c1,*t1)
+    return c0 + c1
 
 # Algorithm 22 from https://eprint.iacr.org/2010/354.pdf
 def square(a_000, a_001, a_010, a_011, a_020, a_021, a_100, a_101, a_110, a_111, a_120, a_121):
     t1 = fp6.sub(a_000, a_001, a_010, a_011, a_020, a_021, a_100, a_101, a_110, a_111, a_120, a_121)
     t2 = fp6.mul_by_gamma(a_100, a_101, a_110, a_111, a_120, a_121)
-    t3 = fp6.sub(a_000, a_001, a_010, a_011, a_020, a_021,t2[0][0],t2[0][1],t2[1][0],t2[1][1],t2[2][0],t2[2][1])
+    t3 = fp6.sub(a_000, a_001, a_010, a_011, a_020, a_021,*t2)
     t4 = fp6.mul(a_000, a_001, a_010, a_011, a_020, a_021, a_100, a_101, a_110, a_111, a_120, a_121)
-    t5 = fp6.mul(t1[0][0],t1[0][1],t1[1][0],t1[1][1],t1[2][0],t1[2][1],t3[0][0],t3[0][1],t3[1][0],t3[1][1],t3[2][0],t3[2][1])
-    t6 = fp6.add(t4[0][0],t4[0][1],t4[1][0],t4[1][1],t4[2][0],t4[2][1],t5[0][0],t5[0][1],t5[1][0],t5[1][1],t5[2][0],t5[2][1])
-    c1 = fp6.add(t4[0][0],t4[0][1],t4[1][0],t4[1][1],t4[2][0],t4[2][1],t4[0][0],t4[0][1],t4[1][0],t4[1][1],t4[2][0],t4[2][1])
-    t8 = fp6.mul_by_gamma(t4[0][0],t4[0][1],t4[1][0],t4[1][1],t4[2][0],t4[2][1])
-    c0 = fp6.add(t6[0][0],t6[0][1],t6[1][0],t6[1][1],t6[2][0],t6[2][1],t8[0][0],t8[0][1],t8[1][0],t8[1][1],t8[2][0],t8[2][1])
-    return c0, c1
+    t5 = fp6.mul(*t1,*t3)
+    t6 = fp6.add(*t4,*t5)
+    c1 = fp6.add(*t4,*t4)
+    t8 = fp6.mul_by_gamma(*t4)
+    c0 = fp6.add(*t6,*t8)
+    return c0 + c1
 
 # Algorithm 23 from https://eprint.iacr.org/2010/354.pdf
 def inv(a_000, a_001, a_010, a_011, a_020, a_021, a_100, a_101, a_110, a_111, a_120, a_121):
     t0 = fp6.square(a_000, a_001, a_010, a_011, a_020, a_021)
     t1 = fp6.square(a_100, a_101, a_110, a_111, a_120, a_121)
-    t2 = fp6.mul_by_gamma(t1[0][0],t1[0][1],t1[1][0],t1[1][1],t1[2][0],t1[2][1])
-    t0 = fp6.sub(t0[0][0],t0[0][1],t0[1][0],t0[1][1],t0[2][0],t0[2][1],t2[0][0],t2[0][1],t2[1][0],t2[1][1],t2[2][0],t2[2][1])
-    t1 = fp6.inv(t0[0][0],t0[0][1],t0[1][0],t0[1][1],t0[2][0],t0[2][1])
-    c0 = fp6.mul(a_000, a_001, a_010, a_011, a_020, a_021, t1[0][0],t1[0][1],t1[1][0],t1[1][1],t1[2][0],t1[2][1])
+    t2 = fp6.mul_by_gamma(*t1)
+    t0 = fp6.sub(*t0,*t2)
+    t1 = fp6.inv(*t0)
+    c0 = fp6.mul(a_000, a_001, a_010, a_011, a_020, a_021, *t1)
     minus_one = fp6.sub(*FP6_ZERO, *FP6_ONE)
-    c1 = fp6.mul(minus_one[0][0],minus_one[0][1],minus_one[1][0],minus_one[1][1],minus_one[2][0],minus_one[2][1], a_100, a_101, a_110, a_111, a_120, a_121)
-    c1 = fp6.mul(c1[0][0],c1[0][1],c1[1][0],c1[1][1],c1[2][0],c1[2][1], t1[0][0],t1[0][1],t1[1][0],t1[1][1],t1[2][0],t1[2][1])
-    return c0, c1
+    c1 = fp6.mul(*minus_one, a_100, a_101, a_110, a_111, a_120, a_121)
+    c1 = fp6.mul(*c1,*t1)
+    return c0 + c1
 
 def main():
 
-    fp12_zero = [0 for _ in range(12)]
-    fp12_one = [monty.ONE] + [0 for _ in range(11)]
-    fp12_two = [monty.TWO] + [0 for _ in range(11)]
-    fp12_all_one = [monty.ONE for _ in range(12)]
-    fp12_all_two = [monty.TWO for _ in range(12)]
+    fp12_zero = tuple([0 for _ in range(12)])
+    fp12_one = tuple([monty.ONE] + [0 for _ in range(11)])
+    fp12_two = tuple([monty.TWO] + [0 for _ in range(11)])
+    fp12_all_one = tuple([monty.ONE for _ in range(12)])
+    fp12_all_two = tuple([monty.TWO for _ in range(12)])
 
     # ADDITION
-    assert(add(*fp12_zero, *fp12_zero) == (((0, 0), (0, 0), (0, 0)), ((0, 0), (0, 0), (0, 0))))
-    assert(add(*fp12_zero, *fp12_all_one) == (((monty.ONE, monty.ONE), (monty.ONE, monty.ONE), (monty.ONE, monty.ONE)), ((monty.ONE, monty.ONE), (monty.ONE, monty.ONE), (monty.ONE, monty.ONE))))
-    assert(add(*fp12_all_one, *fp12_zero) == (((monty.ONE, monty.ONE), (monty.ONE, monty.ONE), (monty.ONE, monty.ONE)), ((monty.ONE, monty.ONE), (monty.ONE, monty.ONE), (monty.ONE, monty.ONE))))
-    assert(add(*fp12_all_one, *fp12_all_one) == (((monty.TWO, monty.TWO), (monty.TWO, monty.TWO), (monty.TWO, monty.TWO)), ((monty.TWO, monty.TWO), (monty.TWO, monty.TWO), (monty.TWO, monty.TWO))))
+    assert(add(*fp12_zero, *fp12_zero) == fp12_zero)
+    assert(add(*fp12_zero, *fp12_all_one) == fp12_all_one)
+    assert(add(*fp12_all_one, *fp12_zero) == fp12_all_one)
+    assert(add(*fp12_all_one, *fp12_all_one) == fp12_all_two)
 
     # SUBTRACTION
-    assert(sub(*fp12_zero, *fp12_zero) == (((0, 0), (0, 0), (0, 0)), ((0, 0), (0, 0), (0, 0))))
-    assert(sub(*fp12_all_two, *fp12_all_one) == (((monty.ONE, monty.ONE), (monty.ONE, monty.ONE), (monty.ONE, monty.ONE)), ((monty.ONE, monty.ONE), (monty.ONE, monty.ONE), (monty.ONE, monty.ONE))))
-    assert(sub(*fp12_all_one, *fp12_zero) == (((monty.ONE, monty.ONE), (monty.ONE, monty.ONE), (monty.ONE, monty.ONE)), ((monty.ONE, monty.ONE), (monty.ONE, monty.ONE), (monty.ONE, monty.ONE))))
-    assert(sub(*fp12_all_one, *fp12_all_one) == (((0, 0), (0, 0), (0, 0)), ((0, 0), (0, 0), (0, 0))))
+    assert(sub(*fp12_zero, *fp12_zero) == fp12_zero)
+    assert(sub(*fp12_all_two, *fp12_all_one) == fp12_all_one)
+    assert(sub(*fp12_all_one, *fp12_zero) == fp12_all_one)
+    assert(sub(*fp12_all_one, *fp12_all_one) == fp12_zero)
 
     # MULTIPLICATION BY 0
-    assert(mul(*fp12_zero, *fp12_zero)) == (((0, 0), (0, 0), (0, 0)), ((0, 0), (0, 0), (0, 0)))
-    assert(mul(*fp12_all_one, *fp12_zero)) == (((0, 0), (0, 0), (0, 0)), ((0, 0), (0, 0), (0, 0)))
-    assert(mul(*fp12_zero, *fp12_all_two)) == (((0, 0), (0, 0), (0, 0)), ((0, 0), (0, 0), (0, 0)))
+    assert(mul(*fp12_zero, *fp12_zero) == fp12_zero)
+    assert(mul(*fp12_all_one, *fp12_zero) == fp12_zero)
+    assert(mul(*fp12_zero, *fp12_all_two) == fp12_zero)
 
     # MULTIPLICATION BY 1
-    assert(mul(*fp12_all_one, *fp12_one)) == (((monty.ONE, monty.ONE), (monty.ONE, monty.ONE), (monty.ONE, monty.ONE)), ((monty.ONE, monty.ONE), (monty.ONE, monty.ONE), (monty.ONE, monty.ONE)))
-    assert(mul(*fp12_one, *fp12_all_two)) == (((monty.TWO, monty.TWO), (monty.TWO, monty.TWO), (monty.TWO, monty.TWO)), ((monty.TWO, monty.TWO), (monty.TWO, monty.TWO), (monty.TWO, monty.TWO)))
+    assert(mul(*fp12_all_one, *fp12_one) == fp12_all_one)
+    assert(mul(*fp12_one, *fp12_all_two) == fp12_all_two)
 
     # MULTIPLICATION BY 2
-    assert(mul(*fp12_all_one, *fp12_two)==add(*fp12_all_one, *fp12_all_one))
-    assert(mul(*fp12_two, *fp12_all_two)==add(*fp12_all_two, *fp12_all_two))
+    assert(mul(*fp12_all_one, *fp12_two) == add(*fp12_all_one, *fp12_all_one))
+    assert(mul(*fp12_two, *fp12_all_two) == add(*fp12_all_two, *fp12_all_two))
 
     # SQUARE OF 0 and 1
-    assert(square(*fp12_zero) == (((0, 0), (0, 0), (0, 0)), ((0, 0), (0, 0), (0, 0))))
-    assert(square(*fp12_one) == (((monty.ONE, 0), (0, 0), (0, 0)), ((0, 0), (0, 0), (0, 0))))
+    assert(square(*fp12_zero) == fp12_zero)
+    assert(square(*fp12_one) == fp12_one)
 
     # MULTIPLICATION AND SQUARE
     assert(mul(*fp12_one, *fp12_one) == square(*fp12_one))
@@ -98,17 +98,11 @@ def main():
     assert(mul(*fp12_all_two, *fp12_all_two) == square(*fp12_all_two))
 
     # MULTIPLY BY INVERSE
-    assert(inv(*fp12_one) == (((monty.ONE, 0), (0, 0), (0, 0)), ((0, 0), (0, 0), (0, 0))))
+    assert(inv(*fp12_one) == fp12_one)
     fp12_all_one_inverse = inv(*fp12_all_one)
     fp12_all_two_inverse = inv(*fp12_all_two)
-    assert(mul(
-        *fp12_all_one,
-        *fp12_all_one_inverse[0][0],*fp12_all_one_inverse[0][1],*fp12_all_one_inverse[0][2],*fp12_all_one_inverse[1][0],*fp12_all_one_inverse[1][1],*fp12_all_one_inverse[1][2]
-    ) == (((monty.ONE, 0), (0, 0), (0, 0)), ((0, 0), (0, 0), (0, 0))))
-    assert(mul(
-        *fp12_all_two_inverse[0][0],*fp12_all_two_inverse[0][1],*fp12_all_two_inverse[0][2],*fp12_all_two_inverse[1][0],*fp12_all_two_inverse[1][1],*fp12_all_two_inverse[1][2],
-        *fp12_all_two,
-    ) == (((monty.ONE, 0), (0, 0), (0, 0)), ((0, 0), (0, 0), (0, 0))))
+    assert(mul(*fp12_all_one,*fp12_all_one_inverse) == fp12_one)
+    assert(mul(*fp12_all_two_inverse, *fp12_all_two) == fp12_one)
 
 
 if __name__ == '__main__':

--- a/scripts/fp6.py
+++ b/scripts/fp6.py
@@ -6,14 +6,14 @@ def add(a_00, a_01, a_10, a_11, a_20, a_21, b_00, b_01, b_10, b_11, b_20, b_21):
     c0 = fp2.add(a_00, a_01, b_00, b_01)
     c1 = fp2.add(a_10, a_11, b_10, b_11)
     c2 = fp2.add(a_20, a_21, b_20, b_21)
-    return c0, c1, c2
+    return c0 + c1 + c2
 
 # Algorithm 11 from https://eprint.iacr.org/2010/354.pdf
 def sub(a_00, a_01, a_10, a_11, a_20, a_21, b_00, b_01, b_10, b_11, b_20, b_21):
     c0 = fp2.sub(a_00, a_01, b_00, b_01)
     c1 = fp2.sub(a_10, a_11, b_10, b_11)
     c2 = fp2.sub(a_20, a_21, b_20, b_21)
-    return c0, c1, c2
+    return c0 + c1 + c2
 
 # Algorithm 13 from https://eprint.iacr.org/2010/354.pdf
 def mul(a_00, a_01, a_10, a_11, a_20, a_21, b_00, b_01, b_10, b_11, b_20, b_21):
@@ -23,7 +23,7 @@ def mul(a_00, a_01, a_10, a_11, a_20, a_21, b_00, b_01, b_10, b_11, b_20, b_21):
     c0 = fp2.add(*fp2.mul_by_xi(*fp2.sub(*fp2.sub(*fp2.mul(*fp2.add(a_10, a_11, a_20, a_21), *fp2.add(b_10, b_11, b_20, b_21)), *t1), *t2)), *t0)
     c1 = fp2.add(*fp2.sub(*fp2.sub(*fp2.mul(*fp2.add(a_00, a_01, a_10, a_11), *fp2.add(b_00, b_01, b_10, b_11)), *t0), *t1), *fp2.mul_by_xi(*t2))
     c2 = fp2.add(*fp2.sub(*fp2.sub(*fp2.mul(*fp2.add(a_00, a_01, a_20, a_21), *fp2.add(b_00, b_01, b_20, b_21)), *t0), *t2), *t1)
-    return c0, c1, c2
+    return c0 + c1 + c2
 
 # Algorithm 16 from https://eprint.iacr.org/2010/354.pdf
 def square(a_00, a_01, a_10, a_11, a_20, a_21):
@@ -37,7 +37,7 @@ def square(a_00, a_01, a_10, a_11, a_20, a_21):
     c4 = fp2.exp(*c4, 2)
     c0 = fp2.add(*fp2.mul_by_xi(*c5), *c3)
     c2 = fp2.sub(*fp2.add(*fp2.add(*c2, *c4), *c5), *c3)
-    return c0, c1, c2
+    return c0 + c1 + c2
 
 # Algorithm 17 from https://eprint.iacr.org/2010/354.pdf
 # Step 9 is wrong in the paper, it should be: t1 - t4
@@ -59,14 +59,14 @@ def inv(a_00, a_01, a_10, a_11, a_20, a_21):
     c1 = fp2.mul(*c1, *t6)
     c2 = fp2.mul(*c2, *t6)
 
-    return c0, c1, c2
+    return c0 + c1 + c2
 
 def mul_by_gamma(a_00, a_01, a_10, a_11, a_20, a_21):
     c0 = fp2.mul_by_xi(a_20, a_21)
     c1 = a_00, a_01
     c2 = a_10, a_11
 
-    return c0, c1, c2
+    return c0 + c1 + c2
 
 def main():
     # (1, 2) + (1, 2)x + (1, 2)x^2
@@ -82,12 +82,12 @@ def main():
     # ADDITION
     fp6_ab = add(*fp2_a_0, *fp2_a_1, *fp2_a_2, *fp2_b_0, *fp2_b_1, *fp2_b_2)
 
-    assert(monty.out_of(fp6_ab[0][0]) == 3)
-    assert(monty.out_of(fp6_ab[0][1]) == 4)
-    assert(monty.out_of(fp6_ab[1][0]) == 3)
-    assert(monty.out_of(fp6_ab[1][1]) == 4)
-    assert(monty.out_of(fp6_ab[2][0]) == 3)
-    assert(monty.out_of(fp6_ab[2][1]) == 4)
+    assert(monty.out_of(fp6_ab[0]) == 3)
+    assert(monty.out_of(fp6_ab[1]) == 4)
+    assert(monty.out_of(fp6_ab[2]) == 3)
+    assert(monty.out_of(fp6_ab[3]) == 4)
+    assert(monty.out_of(fp6_ab[4]) == 3)
+    assert(monty.out_of(fp6_ab[5]) == 4)
 
     # SUBTRACTION
 
@@ -98,35 +98,35 @@ def main():
 
     fp6_ab = sub(*fp2_a_0, *fp2_a_1, *fp2_a_2, *fp2_b_0, *fp2_b_1, *fp2_b_2)
 
-    assert(monty.out_of(fp6_ab[0][0]) == 0)
-    assert(monty.out_of(fp6_ab[0][1]) == 0)
-    assert(monty.out_of(fp6_ab[1][0]) == 0)
-    assert(monty.out_of(fp6_ab[1][1]) == 1)
-    assert(monty.out_of(fp6_ab[2][0]) == 0)
-    assert(monty.out_of(fp6_ab[2][1]) == 2)
+    assert(monty.out_of(fp6_ab[0]) == 0)
+    assert(monty.out_of(fp6_ab[1]) == 0)
+    assert(monty.out_of(fp6_ab[2]) == 0)
+    assert(monty.out_of(fp6_ab[3]) == 1)
+    assert(monty.out_of(fp6_ab[4]) == 0)
+    assert(monty.out_of(fp6_ab[5]) == 2)
 
     # SQUARE AND MULTIPLICATION
 
     fp6_squared = square(*fp2_a_0, *fp2_a_1, *fp2_a_2)
     fp6_mul_squared = mul(*fp2_a_0, *fp2_a_1, *fp2_a_2, *fp2_a_0, *fp2_a_1, *fp2_a_2)
     
-    assert(fp6_squared[0][0] == fp6_mul_squared[0][0])
-    assert(fp6_squared[0][1] == fp6_mul_squared[0][1])
-    assert(fp6_squared[1][0] == fp6_mul_squared[1][0])
-    assert(fp6_squared[1][1] == fp6_mul_squared[1][1])
-    assert(fp6_squared[2][0] == fp6_mul_squared[2][0])
-    assert(fp6_squared[2][1] == fp6_mul_squared[2][1])
+    assert(fp6_squared[0] == fp6_mul_squared[0])
+    assert(fp6_squared[1] == fp6_mul_squared[1])
+    assert(fp6_squared[2] == fp6_mul_squared[2])
+    assert(fp6_squared[3] == fp6_mul_squared[3])
+    assert(fp6_squared[4] == fp6_mul_squared[4])
+    assert(fp6_squared[5] == fp6_mul_squared[5])
 
     # INVERSE
     fp6_inversed = inv(*fp2_a_0, *fp2_a_1, *fp2_a_2)
-    fp6_zero = mul(*fp2_a_0, *fp2_a_1, *fp2_a_2, *fp6_inversed[0], *fp6_inversed[1], *fp6_inversed[2])
+    fp6_zero = mul(*fp2_a_0, *fp2_a_1, *fp2_a_2, *fp6_inversed)
 
-    assert(fp6_zero[0][0] == monty.ONE)
-    assert(fp6_zero[0][1] == 0)
-    assert(fp6_zero[1][0] == 0)
-    assert(fp6_zero[1][1] == 0)
-    assert(fp6_zero[2][0] == 0)
-    assert(fp6_zero[2][1] == 0)
+    assert(fp6_zero[0] == monty.ONE)
+    assert(fp6_zero[1] == 0)
+    assert(fp6_zero[2] == 0)
+    assert(fp6_zero[3] == 0)
+    assert(fp6_zero[4] == 0)
+    assert(fp6_zero[5] == 0)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
The pairing functions mostly operates with fp12 arithmetics, in order to make that code simpler we change the return type of `fp6` and `fp12` to one single tuple with all the coefficients instead of multiple tuples representing the elements of the extensions.