### PR TITLE
Remove unecesary mod

### DIFF
--- a/precompiles/EcMul.yul
+++ b/precompiles/EcMul.yul
@@ -217,9 +217,8 @@ object "EcMul" {
             /// @param a The field element to encode.
             /// @return ret The field element in Montgomery form.
             function intoMontgomeryForm(a) -> ret {
-                let temp := mod(a, P())
-                let hi := getHighestHalfOfMultiplication(temp, R2_MOD_P())
-                let lo := mul(temp, R2_MOD_P())
+                let hi := getHighestHalfOfMultiplication(a, R2_MOD_P())
+                let lo := mul(a, R2_MOD_P())
                 ret := REDC(lo, hi)
             }
 


### PR DESCRIPTION
Resolves [Issue 67](https://github.com/lambdaclass/zksync_era_precompiles/issues/67).

The `mod(a, P())` inside the function 'intoMontgomeryForm(a)' is unnecessary since a prior check is performed: `affinePointCoordinatesAreOnGroupOrder()`, which guarantees that a < P."