### PR TITLE
Substraction with borrow

### DIFF
--- a/precompiles/Modexp.yul
+++ b/precompiles/Modexp.yul
@@ -6,6 +6,20 @@ object "ModExp" {
             //                      CONSTANTS
             ////////////////////////////////////////////////////////////////
 
+            function console_log(val) -> {
+                let log_address := 0x000000000000000000636F6e736F6c652e6c6f67
+                // A big memory address to store the function selector.
+                let freeMemPointer := 0x600
+                // store the function selector of log(uint256) in memory
+                mstore(freeMemPointer, 0xf82c50f1) // mem[0] = 0xf8...
+                // store the first argument of log(uint256) in the next memory slot
+                mstore(add(freeMemPointer, 0x20), val)
+                // call the console.log contract
+                if iszero(staticcall(gas(),log_address,add(freeMemPointer, 28),add(freeMemPointer, 0x40),0x00,0x00)) {
+                    revert(0,0)
+                }
+            }
+
             function WORD_SIZE() -> word {
                 word := 0x20
             }

--- a/precompiles/Modexp.yul
+++ b/precompiles/Modexp.yul
@@ -42,36 +42,36 @@ object "ModExp" {
             /// @dev Reference: https://github.com/lambdaclass/lambdaworks/blob/main/math/src/unsigned_integer/element.rs#L785
             /// @param leftLimb The left side of the difference (i.e. the a in a - b).
             /// @param rightLimb The right side of the difference (i.e. the b in a - b).
-            /// @return substractionResult i.e. the c in c = a - b.
-            /// @return returnBorrow If there was any borrow on the substraction, is returned as 1.
-            function subLimbsWithBorrow(leftLimb, rightLimb, limbBorrow) -> substractionResult, returnBorrow {
+            /// @return subtractionResult i.e. the c in c = a - b.
+            /// @return returnBorrow If there was any borrow on the subtraction, is returned as 1.
+            function subLimbsWithBorrow(leftLimb, rightLimb, limbBorrow) -> subtractionResult, returnBorrow {
                 let rightPlusBorrow := add(rightLimb, limbBorrow)
-                substractionResult := sub(leftLimb, rightPlusBorrow)
-                if gt(substractionResult, leftLimb) {
+                subtractionResult := sub(leftLimb, rightPlusBorrow)
+                if gt(subtractionResult, leftLimb) {
                  returnBorrow := 1
                 }
             }
-            /// @notice Computes the BigUint substraction between the number stored
+            /// @notice Computes the BigUint subtraction between the number stored
             /// in lshPointer and rhsPointer.
             /// @dev Reference: https://github.com/lambdaclass/lambdaworks/blob/main/math/src/unsigned_integer/element.rs#L795
-            /// @param lhsPointer The start of the left hand side substraction Big Number.
-            /// @param rhsPointer The start of the right hand side substraction Big Number.
+            /// @param lhsPointer The start of the left hand side subtraction Big Number.
+            /// @param rhsPointer The start of the right hand side subtraction Big Number.
             /// @return numberOfLimbs The number of limbs of both numbers.
             /// @return resultPointer Where the result will be stored.
-            function bigUintSubstractionWithBorrow(lhsPointer, rhsPointer, numberOfLimbs, resultPointer) -> resultPointer, borrow {
+            function bigUintSubtractionWithBorrow(lhsPointer, rhsPointer, numberOfLimbs, resultPointer) -> resultPointer, borrow {
                 let leftIthLimbValue
                 let rightIthLimbValue
-                let ithLimbBorrowResult 
-                let ithLimbSubstractionResult 
+                let ithLimbBorrowResult
+                let ithLimbSubtractionResult
                 let borrow := 0
                 let limbOffset := 0
                 for {let i := numberOfLimbs} gt(i, 0) {i := sub(i, 1)} {
                     limbOffset := mul(sub(i,1), 32)
                     leftIthLimbValue := getLimbValueAtOffset(lhsPointer, limbOffset)
                     rightIthLimbValue := getLimbValueAtOffset(rhsPointer, limbOffset)
-                    ithLimbSubstractionResult, borrow :=
+                    ithLimbSubtractionResult, borrow :=
                                                subLimbsWithBorrow(leftIthLimbValue, rightIthLimbValue, borrow)
-                    storeLimbValueAtOffset(resultPointer, limbOffset, ithLimbSubstractionResult)
+                    storeLimbValueAtOffset(resultPointer, limbOffset, ithLimbSubtractionResult)
 
                 }
             }
@@ -107,10 +107,10 @@ object "ModExp" {
             let padded_base_pointer := add(96, base_padding)
             calldatacopy(padded_base_pointer, base_pointer, base_length)
             let base := mload(base_pointer)
-            
+
             // As the exponent length could be more than 32 bytes we
             // decided to represent the exponent with limbs. Because
-            // of that, we keep track of a calldata pointer and a memory 
+            // of that, we keep track of a calldata pointer and a memory
             // pointer.
             //
             // The calldata pointer keeps track of the real exponent length
@@ -118,21 +118,21 @@ object "ModExp" {
             // The memory pointer keeps track of the adjusted exponent length
             // (which is always divisible by the word size).
             //
-            // There is a special case to handle when the leftmost limb of 
-            // the exponent has less than 32 bytes in the calldata (e.g. if 
-            // the calldata has 33 bytes in the calldata, in our limbs 
+            // There is a special case to handle when the leftmost limb of
+            // the exponent has less than 32 bytes in the calldata (e.g. if
+            // the calldata has 33 bytes in the calldata, in our limbs
             // representation it should have 64 bytes). Here is where it
             // it could be a difference between the real exponent length and
             // the adjusted exponent length.
             //
-            // For the amount of limbs, if the exponent length is divisible 
-            // by the word size, then we just divide it by the word size. 
+            // For the amount of limbs, if the exponent length is divisible
+            // by the word size, then we just divide it by the word size.
             // If not, we divide and then add the remainder limb (this is
             // the case when the leftmost limb has less than 32 bytes).
             //
             // In the special case, the memory exponent pointer and the
             // calldata exponent pointer are outphased. That's why after
-            // loading the exponent from the calldata, we still need to 
+            // loading the exponent from the calldata, we still need to
             // compute two pointers for the modulus.
             let calldata_exponent_pointer := add(base_pointer, base_length)
             let memory_exponent_pointer := add(base_pointer, WORD_SIZE())
@@ -214,7 +214,7 @@ object "ModExp" {
                     exponent := shr(1, exponent)
                     base := mulmod(base, base, modulus)
                 }
-    
+
                 mstore(0, pow)
                 let unpadding := sub(WORD_SIZE(), modulus_length)
                 return(unpadding, modulus_length)

--- a/precompiles/Modexp.yul
+++ b/precompiles/Modexp.yul
@@ -76,52 +76,6 @@ object "ModExp" {
                 }
             }
 
-
-
-
-            // Test4: Big number 4 limb substraction
-            // First Number:
-            //  - First Limb: 0xFFFF
-            //  - Second Limb: 0xAAAA
-            //  - Third Limb: 0xFFFF
-            //  - Fourth Limb: 0xAAAA
-            // Second Number:
-            //  - First Limb: 0xAAAA
-            //  - Second Limb: 0xFFFF
-            //  - Third Limb: 0xAAAA
-            //  - Fourth Limb: 0xFFF
-            //  
-            // Should print:
-            // 0x5554 (first limb)
-            // 0xffffffffffffaaab (second limb)
-            // 0x5555 (third limb)
-            // 0x9aab (fourth limb)
-            
-
-            mstore(0x00, 0xffff)
-            mstore(0x20, 0xaaaa)
-            mstore(0x40, 0xffff)
-            mstore(0x60, 0xaaaa)
-
-            mstore(0x80, 0xaaaa)
-            mstore(0xa0, 0xffff)
-            mstore(0xc0, 0xaaaa)
-            mstore(0xe0, 0xfff)
-
-
-            let retStart := 0x100
-            let _, borrow := bigUintSubstractionWithBorrow(0x00, 0x80, 4, retStart)
-
-            let res := mload(retStart)
-            let res2 := mload(add(retStart, 0x20))
-            let res3 := mload(add(retStart, 0x40))
-            let res4 := mload(add(retStart, 0x60))
-
-            console_log(res)
-            console_log(res2)
-            console_log(res3)
-            console_log(res4)
-            // console_log(sub(0x0, 0x1))
             ////////////////////////////////////////////////////////////////
             //                      FALLBACK
             ////////////////////////////////////////////////////////////////

--- a/precompiles/Modexp.yul
+++ b/precompiles/Modexp.yul
@@ -107,10 +107,10 @@ object "ModExp" {
             let padded_base_pointer := add(96, base_padding)
             calldatacopy(padded_base_pointer, base_pointer, base_length)
             let base := mload(base_pointer)
-
+            
             // As the exponent length could be more than 32 bytes we
             // decided to represent the exponent with limbs. Because
-            // of that, we keep track of a calldata pointer and a memory
+            // of that, we keep track of a calldata pointer and a memory 
             // pointer.
             //
             // The calldata pointer keeps track of the real exponent length
@@ -118,21 +118,21 @@ object "ModExp" {
             // The memory pointer keeps track of the adjusted exponent length
             // (which is always divisible by the word size).
             //
-            // There is a special case to handle when the leftmost limb of
-            // the exponent has less than 32 bytes in the calldata (e.g. if
-            // the calldata has 33 bytes in the calldata, in our limbs
+            // There is a special case to handle when the leftmost limb of 
+            // the exponent has less than 32 bytes in the calldata (e.g. if 
+            // the calldata has 33 bytes in the calldata, in our limbs 
             // representation it should have 64 bytes). Here is where it
             // it could be a difference between the real exponent length and
             // the adjusted exponent length.
             //
-            // For the amount of limbs, if the exponent length is divisible
-            // by the word size, then we just divide it by the word size.
+            // For the amount of limbs, if the exponent length is divisible 
+            // by the word size, then we just divide it by the word size. 
             // If not, we divide and then add the remainder limb (this is
             // the case when the leftmost limb has less than 32 bytes).
             //
             // In the special case, the memory exponent pointer and the
             // calldata exponent pointer are outphased. That's why after
-            // loading the exponent from the calldata, we still need to
+            // loading the exponent from the calldata, we still need to 
             // compute two pointers for the modulus.
             let calldata_exponent_pointer := add(base_pointer, base_length)
             let memory_exponent_pointer := add(base_pointer, WORD_SIZE())
@@ -214,7 +214,7 @@ object "ModExp" {
                     exponent := shr(1, exponent)
                     base := mulmod(base, base, modulus)
                 }
-
+    
                 mstore(0, pow)
                 let unpadding := sub(WORD_SIZE(), modulus_length)
                 return(unpadding, modulus_length)

--- a/precompiles/Modexp.yul
+++ b/precompiles/Modexp.yul
@@ -369,15 +369,14 @@ object "ModExp" {
                 let ithLimbBorrowResult
                 let ithLimbSubtractionResult
                 let borrow := 0
-                let limbOffset := 0
+                let limbOffset := shl(5, numberOfLimbs)
                 for {let i := numberOfLimbs} gt(i, 0) {i := sub(i, 1)} {
-                    limbOffset := mul(sub(i,1), 32)
                     leftIthLimbValue := getLimbValueAtOffset(lhsPointer, limbOffset)
                     rightIthLimbValue := getLimbValueAtOffset(rhsPointer, limbOffset)
                     ithLimbSubtractionResult, borrow :=
                                                subLimbsWithBorrow(leftIthLimbValue, rightIthLimbValue, borrow)
                     storeLimbValueAtOffset(resultPointer, limbOffset, ithLimbSubtractionResult)
-
+                    limbOffset := sub(limbOffset, LIMB_SIZE_IN_BYTES())
                 }
             }
 

--- a/precompiles/Modexp.yul
+++ b/precompiles/Modexp.yul
@@ -369,14 +369,15 @@ object "ModExp" {
                 let ithLimbBorrowResult
                 let ithLimbSubtractionResult
                 let borrow := 0
-                let limbOffset := shl(5, numberOfLimbs)
+                let limbOffset := 0
                 for {let i := numberOfLimbs} gt(i, 0) {i := sub(i, 1)} {
+                    limbOffset := mul(sub(i,1), 32)
                     leftIthLimbValue := getLimbValueAtOffset(lhsPointer, limbOffset)
                     rightIthLimbValue := getLimbValueAtOffset(rhsPointer, limbOffset)
                     ithLimbSubtractionResult, borrow :=
                                                subLimbsWithBorrow(leftIthLimbValue, rightIthLimbValue, borrow)
                     storeLimbValueAtOffset(resultPointer, limbOffset, ithLimbSubtractionResult)
-                    limbOffset := sub(limbOffset, LIMB_SIZE_IN_BYTES())
+
                 }
             }
 

--- a/precompiles/Modexp.yul
+++ b/precompiles/Modexp.yul
@@ -29,31 +29,40 @@ object "ModExp" {
             }
 
             function getLimbValueAtOffset(limbPointer, anOffset) -> limbValue {
-                limbValue := mload(limbPointer, anOffset)
+                limbValue := mload(add(anOffset, limbPointer))
             }
 
             function storeLimbValueAtOffset(limbPointer, anOffset, aValue) {
                     mstore(add(limbPointer, anOffset), aValue)
             }
+
             function subLimbsWithBorrow(leftLimb, rightLimb, borrow) -> substractionResult, shiftedBorrow {
-                let shiftedBorrow := shr(255, borrow)
+                shiftedBorrow := shr(255, borrow)
                 let rightPlusBorrow := add(rightLimb, borrow)
                 substractionResult := sub(leftLimb, rightPlusBorrow)
             }
 
             function bigUintSubstractionWithBorrow(lhsPointer, rhsPointer, numberOfLimbs, resultPointer) -> resultPointer {
-                let leftIthLimbValue := 0
-                let rightIthLimbValue := 0
-                let ithLimbBorrowResult := 0 
-                let ithLimbSubstractionResult := 0 
-                let borrow := 0
-                let limbResultOffset := 0
-                for {let i := numberOfLimbs} gt(i, 0) {i := sub(i, 1)} {
-                    leftIthLimbValue := getLimbValueAtOffset(lhsPointer, i)
-                    rightIthLimbValue := getLimbValueAtOffset(rhsPointer, i)
+                let leftIthLimbValue
+                let rightIthLimbValue
+                let ithLimbBorrowResult 
+                let ithLimbSubstractionResult 
+                let borrow
+                let limbResultOffset 
+                for {let limbOffset := 0} lt(limbOffset, numberOfLimbs) {limbOffset := add(limbOffset, 1)} {
+                    leftIthLimbValue := getLimbValueAtOffset(lhsPointer, mul(limbOffset, 32))
+                    rightIthLimbValue := getLimbValueAtOffset(rhsPointer, mul(limbOffset, 32))
                     ithLimbSubstractionResult, ithLimbBorrowResult :=
                                                subLimbsWithBorrow(leftIthLimbValue, rightIthLimbValue, borrow)
-                    storeLimbValueAtOffset(resultPointer, i, ithLimbSubstractionResult)
+
+  
+                    // console_log(leftIthLimbValue)
+                    // console_log(rightIthLimbValue)
+
+                    // console_log(ithLimbSubstractionResult)
+
+                    storeLimbValueAtOffset(resultPointer, mul(limbOffset, 32), ithLimbSubstractionResult)
+
                     borrow := ithLimbBorrowResult
                 }
             }

--- a/precompiles/Modexp.yul
+++ b/precompiles/Modexp.yul
@@ -43,7 +43,13 @@ object "ModExp" {
                  returnBorrow := 1
                 }
             }
-
+            /// @notice Computes the BigUint substraction between the number stored
+            /// in lshPointer and rhsPointer.
+            /// @dev Reference: https://github.com/lambdaclass/lambdaworks/blob/main/math/src/unsigned_integer/element.rs#L795
+            /// @param lhsPointer The start of the left hand side substraction Big Number.
+            /// @param rhsPointer The start of the right hand side substraction Big Number.
+            /// @return numberOfLimbs The number of limbs of both numbers.
+            /// @return resultPointer Where the result will be stored.
             function bigUintSubstractionWithBorrow(lhsPointer, rhsPointer, numberOfLimbs, resultPointer) -> resultPointer, borrow {
                 let leftIthLimbValue
                 let rightIthLimbValue

--- a/precompiles/Modexp.yul
+++ b/precompiles/Modexp.yul
@@ -28,6 +28,25 @@ object "ModExp" {
                 isZero := iszero(isZero)
             }
 
+            function getLimbValueAtOffset(limbPointer, anOffset) -> limbValue {
+                limbValue := mload(lhsPointer, anOffset)
+            }
+
+            function subLimbsWithBorrow(leftLimb, rightLimb, borrow) -> substractionResult, shiftedBorrow {
+                shiftedBorrow := borrow >> 255
+                rightPlusBorrow := add(rightLimb, borrow)
+                substractionResult := sub(leftLimb, rightPlusBorrow)
+            }
+
+            function bigUintSubstractionWithBorrow(lhsPointer, rhsPointer, numberOfLimbs, resultPointer) -> resultPointer {
+                for {let i := numberOfLimbs } gt(i, 0) {i := sub(i, 1)} {
+                    leftIthLimbValue := getLimbValueAtOffset(lshPointer, i)
+                    rightIthLimbValue := getLimbValueAtOffset(rhsPointer, i)
+                    ithLimbSubstractionResult, ithLimbBorrowResult := subLimbsWithBorrow(leftIthLimbValue, rightIthLimbValue, borrow)
+                    mstore(limbResultOffset, ithLimbSubstractionResult)
+                    borrow := ithLimbBorrowResult
+                }
+            }
             ////////////////////////////////////////////////////////////////
             //                      FALLBACK
             ////////////////////////////////////////////////////////////////

--- a/precompiles/Modexp.yul
+++ b/precompiles/Modexp.yul
@@ -6,20 +6,6 @@ object "ModExp" {
             //                      CONSTANTS
             ////////////////////////////////////////////////////////////////
 
-            function console_log(val) -> {
-                let log_address := 0x000000000000000000636F6e736F6c652e6c6f67
-                // A big memory address to store the function selector.
-                let freeMemPointer := 0x600
-                // store the function selector of log(uint256) in memory
-                mstore(freeMemPointer, 0xf82c50f1) // mem[0] = 0xf8...
-                // store the first argument of log(uint256) in the next memory slot
-                mstore(add(freeMemPointer, 0x20), val)
-                // call the console.log contract
-                if iszero(staticcall(gas(),log_address,add(freeMemPointer, 28),add(freeMemPointer, 0x40),0x00,0x00)) {
-                    revert(0,0)
-                }
-            }
-
             function WORD_SIZE() -> word {
                 word := 0x20
             }

--- a/precompiles/Modexp.yul
+++ b/precompiles/Modexp.yul
@@ -53,7 +53,9 @@ object "ModExp" {
             function subLimbsWithBorrow(leftLimb, rightLimb, limbBorrow) -> substractionResult, returnBorrow {
                 let rightPlusBorrow := add(rightLimb, limbBorrow)
                 substractionResult := sub(leftLimb, rightPlusBorrow)
-                returnBorrow := shr(255, substractionResult)
+                if gt(substractionResult, leftLimb) {
+                 returnBorrow := 1
+                }
             }
 
             function bigUintSubstractionWithBorrow(lhsPointer, rhsPointer, numberOfLimbs, resultPointer) -> resultPointer, borrow {

--- a/precompiles/Modexp.yul
+++ b/precompiles/Modexp.yul
@@ -29,21 +29,31 @@ object "ModExp" {
             }
 
             function getLimbValueAtOffset(limbPointer, anOffset) -> limbValue {
-                limbValue := mload(lhsPointer, anOffset)
+                limbValue := mload(limbPointer, anOffset)
             }
 
+            function storeLimbValueAtOffset(limbPointer, anOffset, aValue) {
+                    mstore(add(limbPointer, anOffset), aValue)
+            }
             function subLimbsWithBorrow(leftLimb, rightLimb, borrow) -> substractionResult, shiftedBorrow {
-                shiftedBorrow := borrow >> 255
-                rightPlusBorrow := add(rightLimb, borrow)
+                let shiftedBorrow := shr(255, borrow)
+                let rightPlusBorrow := add(rightLimb, borrow)
                 substractionResult := sub(leftLimb, rightPlusBorrow)
             }
 
             function bigUintSubstractionWithBorrow(lhsPointer, rhsPointer, numberOfLimbs, resultPointer) -> resultPointer {
-                for {let i := numberOfLimbs } gt(i, 0) {i := sub(i, 1)} {
-                    leftIthLimbValue := getLimbValueAtOffset(lshPointer, i)
+                let leftIthLimbValue := 0
+                let rightIthLimbValue := 0
+                let ithLimbBorrowResult := 0 
+                let ithLimbSubstractionResult := 0 
+                let borrow := 0
+                let limbResultOffset := 0
+                for {let i := numberOfLimbs} gt(i, 0) {i := sub(i, 1)} {
+                    leftIthLimbValue := getLimbValueAtOffset(lhsPointer, i)
                     rightIthLimbValue := getLimbValueAtOffset(rhsPointer, i)
-                    ithLimbSubstractionResult, ithLimbBorrowResult := subLimbsWithBorrow(leftIthLimbValue, rightIthLimbValue, borrow)
-                    mstore(limbResultOffset, ithLimbSubstractionResult)
+                    ithLimbSubstractionResult, ithLimbBorrowResult :=
+                                               subLimbsWithBorrow(leftIthLimbValue, rightIthLimbValue, borrow)
+                    storeLimbValueAtOffset(resultPointer, i, ithLimbSubstractionResult)
                     borrow := ithLimbBorrowResult
                 }
             }

--- a/precompiles/Modexp.yul
+++ b/precompiles/Modexp.yul
@@ -36,6 +36,14 @@ object "ModExp" {
                     mstore(add(limbPointer, anOffset), aValue)
             }
 
+            /// @notice Computes the difference between two 256 bit number and keeps
+            /// account of the borrow bit
+            /// in lshPointer and rhsPointer.
+            /// @dev Reference: https://github.com/lambdaclass/lambdaworks/blob/main/math/src/unsigned_integer/element.rs#L785
+            /// @param leftLimb The left side of the difference (i.e. the a in a - b).
+            /// @param rightLimb The right side of the difference (i.e. the b in a - b).
+            /// @return substractionResult i.e. the c in c = a - b.
+            /// @return returnBorrow If there was any borrow on the substraction, is returned as 1.
             function subLimbsWithBorrow(leftLimb, rightLimb, limbBorrow) -> substractionResult, returnBorrow {
                 let rightPlusBorrow := add(rightLimb, limbBorrow)
                 substractionResult := sub(leftLimb, rightPlusBorrow)


### PR DESCRIPTION
## Changes
- Closes #133.
- This PR adds a substraction with borrow function for BigUInts (i.e. a-b, where a > b).
## How to test 
   Paste the below snippet into a contract you can call, 
    my recommendation is to paste it into the Modexp.yul contract
    and then run this test: `cargo test modexp_tests_98`
```yul
// Test1: Simple 2 limbs
// First Number:
//  - First Limb: 0x0...0
//  - Second Limb: 0x0...F
// Second Number:
//  - First Limb: 0x0...0
//  - Second Limb: 0x0...A
// [0x0...0, 0x0...F]
// - 
// [0x0...0, 0x0...A]
// ------------------
// [0x0...0, 0x0...5]
// Should print:
// 0 (first limb)
// 5 (second limb)

mstore(0x00, 0x0)
mstore(0x20, 0xF)

mstore(0x40, 0x0)
mstore(0x60, 0xA)

let retStart := 0x80
let _, borrow := bigUintSubstractionWithBorrow(0x00, 0x40, 2, retStart)

let res := mload(retStart)
let res2 := mload(add(retStart, 0x20))
let res3 := mload(add(retStart, 0x40))
let res4 := mload(add(retStart, 0x60))

console_log(res)
console_log(res2)

// Test2: Borrow works as expected
// First Number:
//  - First Limb: 0xFF
//  - Second Limb: 0xAA
// Second Number:
//  - First Limb: 0xAA
//  - Second Limb: 0xFF
// Should print:
// 54 (first limb)
// ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffab (second limb)



mstore(0x00, 0xFF)
mstore(0x20, 0xAA)

mstore(0x40, 0xAA)
mstore(0x60, 0xFF)


let retStart := 0x80
let _, borrow := bigUintSubstractionWithBorrow(0x00, 0x40, 2, retStart)

let res := mload(retStart)
let res2 := mload(add(retStart, 0x20))
let res3 := mload(add(retStart, 0x40))
let res4 := mload(add(retStart, 0x60))

console_log(res)
console_log(res2)

// Test3: Big number 2 limb substraction
// I've tested this againts our reference (Lambdaworks) and gives the same result.
// First Number:
mstore(0x20, 0xffffaaaaaaaaaaaaaaaaffffffffffffffffaaaaaaaaaaaaaaaa)
mstore(0x40, 0xffffffffffffffffaaaaaaaaaaaaaaaaffffffffffffffffaaaaaaaaaaaaaaaa)
// Second Number:
mstore(0x60, 0xaaaaffffffffffffffffaaaaaaaaaaaaaaaaffffffffffffffff)
mstore(0x80, 0xaaaaaaaaaaaaaaaaffffffffffffffffaaaaaaaaaaaaaaaaffffffffffffffff)

let retStart := 0x100
let _, borrow := bigUintSubstractionWithBorrow(0x20, 0x60, 2, retStart)

// Should print:
// 5554aaaaaaaaaaaaaaab5555555555555554aaaaaaaaaaaaaaab
// 5555555555555554aaaaaaaaaaaaaaab5555555555555554aaaaaaaaaaaaaaab            

let res := mload(retStart)
let res2 := mload(add(retStart, 0x20))

console_log(res)
console_log(res2)
```