### PR TITLE
add r check

### DIFF
--- a/precompiles/P256Verify.yul
+++ b/precompiles/P256Verify.yul
@@ -555,7 +555,7 @@ object "P256VERIFY" {
             let x := calldataload(96)
             let y := calldataload(128)
 
-            if or(iszero(fieldElementIsOnSubgroupOrder(r)), iszero(fieldElementIsOnSubgroupOrder(s))) {
+            if or(or(iszero(r), iszero(fieldElementIsOnSubgroupOrder(r))), iszero(fieldElementIsOnSubgroupOrder(s))) {
                 burnGas()
             }
 


### PR DESCRIPTION
The [Signature verification algorithm](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm#Signature_verification_algorithm) requires checking whether the final point of the curve calculated is not the infinity point; otherwise, the signature is considered invalid.

To avoid performing this final check after completing all the computations, we only need to verify whether the value of $r$ is different from zero in the calldata. This is because, for the resulting point to be considered infinity and the signature to be valid, $r$ must be zero.

Additionally, it's important to note that the 'r' parameter of the signature is calculated as follows: $r = x_1 \mod n$ where $(x_1, x_2) = k \cdot G$, with $k$ being a cryptographically secure random integer in the range $[1, n-1]$, and $G$ being the generator. Therefore, $r$ cannot be zero in any valid signature.