### PR TITLE
Add S value verification for P256 curve

### DIFF
--- a/precompiles/P256Verify.yul
+++ b/precompiles/P256Verify.yul
@@ -555,7 +555,7 @@ object "P256VERIFY" {
             let x := calldataload(96)
             let y := calldataload(128)
 
-            if or(or(iszero(r), iszero(fieldElementIsOnSubgroupOrder(r))), iszero(fieldElementIsOnSubgroupOrder(s))) {
+            if or(or(iszero(r), iszero(fieldElementIsOnSubgroupOrder(r))), or(iszero(s), iszero(fieldElementIsOnSubgroupOrder(s)))) {
                 burnGas()
             }
 


### PR DESCRIPTION
This includes the addition of an $s$ value check within the calldata of the precompile. This check ensures that $s$ is not equal to zero, preventing the risk of entering an infinite loop when attempting the inverse operation.