### PR TITLE
fix projectiveAdd

### DIFF
--- a/precompiles/P256VERIFY.yul
+++ b/precompiles/P256VERIFY.yul
@@ -460,18 +460,16 @@ object "P256VERIFY" {
                     zr := zp
                     leave
                 }
-                // FIX ME: we need to check xp/zp == xq/zq and yp/zp == -yq/zq 
-                if and(and(eq(xp, xq), eq(montgomerySub(0, yp, P()), yq)), eq(zp, zq)) {
+                if eq(montgomeryMul(xp, zq, P(), P_PRIME()), montgomeryMul(xq, zp, P(), P_PRIME())) {
+                    if eq(montgomeryMul(yp, zq, P(), P_PRIME()), montgomeryMul(yq, zp, P(), P_PRIME())) {
+                        // P + P = 2P
+                        xr, yr, zr := projectiveDouble(xp, yp, zp)
+                        leave
+                    }
                     // P + (-P) = Infinity
                     xr := 0
                     yr := MONTGOMERY_ONE_P()
                     zr := 0
-                    leave
-                }
-                // FIX ME: we need to check xp/zp == xq/zq and yp/zp == yq/zq 
-                if and(and(eq(xp, xq), eq(yp, yq)), eq(zp, zq)) {
-                    // P + P = 2P
-                    xr, yr, zr := projectiveDouble(xp, yp, zp)
                     leave
                 }
 


### PR DESCRIPTION
To determine if two points on the elliptic curve were the same, it was being checked whether they had the same projective coordinates. This can lead to errors, as a point can have two different projective representations with different coordinates. Therefore, it is now checked that $Xq/Zq == Xp/Zp$ or, using only multiplications: $XqZp == XpZq$.

Also, we can save a check by knowing that if two points have the same X coordinate, there are only two possibilities: either they are the same point or they are each other's negation, causing their sum to be at infinity.