### PR TITLE
Improve makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 era_test_node.log
 submodules/era_test_node
+tests/gas_reports

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,32 @@
-.PHONY: install run copy-precompiles build-precompiles download-node build-node setup-node update-node run-node run-node-light test docs clean
+.PHONY: clean
 
-# Main commands
+current_dir := ${CURDIR}
+era_test_node_base_path := $(current_dir)/submodules/era-test-node
+era_test_node := $(era_test_node_base_path)/target/release/era_test_node
+era_test_node_makefile := $(era_test_node_base_path)/Makefile
+precompile_dst_path := $(era_test_node_base_path)/etc/system-contracts/contracts/precompiles
 
-install: setup-node
-	cp -r precompiles/ submodules/era-test-node/etc/system-contracts/contracts/precompiles && \
-	cd submodules/era-test-node && \
-	make build-contracts
-
-# Precompiles commands
-
-copy-precompiles:
-	cp precompiles/*.yul submodules/era-test-node/etc/system-contracts/contracts/precompiles/
-
-build-precompiles: copy-precompiles
-	cd submodules/era-test-node && \
-	make build-contracts
-
-# Node Commands
-
-download-node:
-	cd submodules && \
-	[ -d "./era-test-node" ] || git clone git@github.com:LambdaClass/era-test-node.git --branch lambdaclasss_precompiles
-
-build-node:
-	cd submodules/era-test-node && make rust-build && make build-contracts
-
-setup-node: download-node build-node
-
-update-node:
-	cd submodules/era-test-node && git pull && make rust-build
-
-run-node:
+run-node: era_test_node
 	./submodules/era-test-node/target/release/era_test_node --show-calls=all --resolve-hashes --show-gas-details=all run
 
-run-node-light:
-	./submodules/era-test-node/target/release/era_test_node run
+run-node-light: era_test_node
+	$(era_test_node) run
 
-# Other commands
+# We could make a better rule for copied_precompiles, as to avoid running the cp everytime, but it's not very relevant. Doing this the precompiles are always updated
+era_test_node: $(era_test_node_makefile) copied_precompiles
+	cd submodules/era-test-node && make rust-build && make build-contracts
+
+copied_precompiles:
+	cp precompiles/*.yul $(precompile_dst_path)
+
+$(era_test_node_makefile):
+	mkdir -p submodules && \
+	cd submodules && \
+	git clone git@github.com:LambdaClass/era-test-node.git --branch lambdaclasss_precompiles
+
+# Node Commands
+update-node: era_test_node
+	cd $(era_test_node_base_path) && git pull && make rust-build
 
 test:
 	cd tests && \
@@ -46,4 +36,4 @@ docs:
 	cd docs && mdbook serve --open
 
 clean:
-	rm submodules/era-test-node/src/deps/contracts/*.yul.zbin submodules/era-test-node/etc/system-contracts/contracts/precompiles/*.yul
+	rm $(era_test_node_base_path)/src/deps/contracts/*.yul.zbin $(era_test_node_base_path)/etc/system-contracts/contracts/precompiles/*.yul

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,6 @@ build-precompiles:
 copied_precompiles:
 	cp precompiles/*.yul $(precompile_dst_path)
 
-build_contracts 
-$(era_test_node_makefile):
-	mkdir -p submodules && \
-	cd submodules && \
-	git clone git@github.com:LambdaClass/era-test-node.git --branch lambdaclasss_precompiles
-
 # Node Commands
 update-node: era_test_node
 	cd $(era_test_node_base_path) && git pull && make rust-build

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ precompile_dst_path := $(era_test_node_base_path)/etc/system-contracts/contracts
 precompiles_source = $(wildcard $(current_dir)/precompiles/*.yul)
 precompiles_dst = $(patsubst $(current_dir)/precompiles/%, $(precompile_dst_path)/%, $(precompiles_source))
 
-print:
-	echo $(precompiles_dst)
-
 run-node: $(era_test_node) $(precompiles_dst)
 	$(era_test_node) --show-calls=all --resolve-hashes --show-gas-details=all run
 

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,9 @@ precompiles_dst = $(patsubst $(current_dir)/precompiles/%, $(precompile_dst_path
 run-node: $(era_test_node) $(precompiles_dst)
 	$(era_test_node) --show-calls=all --resolve-hashes --show-gas-details=all run
 
-run-node-light: $(era_test_node)
+run-node-light: $(era_test_node) $(precompiles_dst)
 	$(era_test_node) run
 
-# We could make a better rule for copied_precompiles, as to avoid running the cp everytime and building the contracts, but it's not very relevant. Doing this the precompiles are always updated
 $(era_test_node): $(era_test_node_makefile)
 	cd $(era_test_node_base_path) && make rust-build
 	

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ era_test_node_makefile := $(era_test_node_base_path)/Makefile
 precompile_dst_path := $(era_test_node_base_path)/etc/system-contracts/contracts/precompiles
 
 run-node: era_test_node
-	./submodules/era-test-node/target/release/era_test_node --show-calls=all --resolve-hashes --show-gas-details=all run
+	.$(era_test_node) --show-calls=all --resolve-hashes --show-gas-details=all run
 
 run-node-light: era_test_node
 	$(era_test_node) run

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ $(era_test_node_makefile):
 	cd submodules && \
 	git clone git@github.com:LambdaClass/era-test-node.git --branch lambdaclasss_precompiles
 
+build-precompiles: $(precompiles_dst)
+
 # Node Commands
 update-node: era_test_node
 	cd $(era_test_node_base_path) && git pull && make rust-build

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ era_test_node := $(era_test_node_base_path)/target/release/era_test_node
 era_test_node_makefile := $(era_test_node_base_path)/Makefile
 precompile_dst_path := $(era_test_node_base_path)/etc/system-contracts/contracts/precompiles
 
-run-node: era_test_node
-	.$(era_test_node) --show-calls=all --resolve-hashes --show-gas-details=all run
+run-node: $(era_test_node)
+	$(era_test_node) --show-calls=all --resolve-hashes --show-gas-details=all run
 
 run-node-light: era_test_node
 	$(era_test_node) run

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ run-node-light: $(era_test_node)
 	$(era_test_node) run
 
 # We could make a better rule for copied_precompiles, as to avoid running the cp everytime and building the contracts, but it's not very relevant. Doing this the precompiles are always updated
-era_test_node: $(era_test_node_makefile) build-precompiles 
+$(era_test_node): $(era_test_node_makefile) build-precompiles 
 	cd $(era_test_node_base_path) && make rust-build
 	
 ## This is only used by the CI

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,18 @@ run-node: era_test_node
 run-node-light: era_test_node
 	$(era_test_node) run
 
-# We could make a better rule for copied_precompiles, as to avoid running the cp everytime, but it's not very relevant. Doing this the precompiles are always updated
-era_test_node: $(era_test_node_makefile) copied_precompiles
-	cd submodules/era-test-node && make rust-build && make build-contracts
+# We could make a better rule for copied_precompiles, as to avoid running the cp everytime and building the contracts, but it's not very relevant. Doing this the precompiles are always updated
+era_test_node: $(era_test_node_makefile) copied_precompiles 
+	cd $(era_test_node_base_path) && make rust-build && make build-contracts
+
+## This is only used by the CI
+build-precompiles:
+	cd $(era_test_node_base_path) && make build-contracts
 
 copied_precompiles:
 	cp precompiles/*.yul $(precompile_dst_path)
 
+build_contracts 
 $(era_test_node_makefile):
 	mkdir -p submodules && \
 	cd submodules && \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,12 @@ era_test_node := $(era_test_node_base_path)/target/release/era_test_node
 era_test_node_makefile := $(era_test_node_base_path)/Makefile
 precompile_dst_path := $(era_test_node_base_path)/etc/system-contracts/contracts/precompiles
 
-run-node: $(era_test_node)
+precompiles_source = $(wildcard $(current_dir)/precompiles/*.yul)
+
+print:
+	echo $(precompiles_source)
+
+run-node: $(era_test_node) build-precompiles 
 	$(era_test_node) --show-calls=all --resolve-hashes --show-gas-details=all run
 
 run-node-light: $(era_test_node)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ era_test_node := $(era_test_node_base_path)/target/release/era_test_node
 era_test_node_makefile := $(era_test_node_base_path)/Makefile
 precompile_dst_path := $(era_test_node_base_path)/etc/system-contracts/contracts/precompiles
 
-precompiles_dst := 
 precompiles_source = $(wildcard $(current_dir)/precompiles/*.yul)
 precompiles_dst = $(patsubst $(current_dir)/precompiles/%, $(precompile_dst_path)/%, $(precompiles_source))
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@ build-precompiles:
 copied_precompiles:
 	cp precompiles/*.yul $(precompile_dst_path)
 
+$(era_test_node_makefile):
+	mkdir -p submodules && \
+	cd submodules && \
+	git clone git@github.com:LambdaClass/era-test-node.git --branch lambdaclasss_precompiles
+
 # Node Commands
 update-node: era_test_node
 	cd $(era_test_node_base_path) && git pull && make rust-build

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,13 @@ precompile_dst_path := $(era_test_node_base_path)/etc/system-contracts/contracts
 run-node: $(era_test_node)
 	$(era_test_node) --show-calls=all --resolve-hashes --show-gas-details=all run
 
-run-node-light: era_test_node
+run-node-light: $(era_test_node)
 	$(era_test_node) run
 
 # We could make a better rule for copied_precompiles, as to avoid running the cp everytime and building the contracts, but it's not very relevant. Doing this the precompiles are always updated
-era_test_node: $(era_test_node_makefile) copied_precompiles 
-	cd $(era_test_node_base_path) && make rust-build && make build-contracts
-
+era_test_node: $(era_test_node_makefile) build-precompiles 
+	cd $(era_test_node_base_path) && make rust-build
+	
 ## This is only used by the CI
 build-precompiles:
 	cd $(era_test_node_base_path) && make build-contracts

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Run one of the following commands to have a working test node.
 make run-node
 make run-node-light # no call trace, no hash resolving, and no gas details
 ```
+### Must run after every change in a precompile
+
+Our precompiles are located in `precompiles/` but as they are there, they're no being tracked by our `era-test-node` clone. We need to always copy our precompiles into the `era-test-node` repo for it to be able to track and compile them for later testing.
+
+```
+make build-precompiles
+```
 
 ### Run the tests
 

--- a/README.md
+++ b/README.md
@@ -60,27 +60,13 @@ You can find a curated list of helpful resources that we've used for guiding our
 
 Follow the instructions below to setup the repo and run a development L2 node.
 
-### Setup the repo
-
-```
-make install
-```
-
 ### Running an era-test-node
 
-Once built, run one of the following commands to have a working test node.
+Run one of the following commands to have a working test node.
 
 ```
 make run-node
 make run-node-light # no call trace, no hash resolving, and no gas details
-```
-
-### Must run after every change in a precompile
-
-Our precompiles are located in `precompiles/` but as they are there, they're no being tracked by our `era-test-node` clone. We need to always copy our precompiles into the `era-test-node` repo for it to be able to track and compile them for later testing.
-
-```
-make build-node
 ```
 
 ### Run the tests

--- a/README.md
+++ b/README.md
@@ -68,13 +68,6 @@ Run one of the following commands to have a working test node.
 make run-node
 make run-node-light # no call trace, no hash resolving, and no gas details
 ```
-### Must run after every change in a precompile
-
-Our precompiles are located in `precompiles/` but as they are there, they're no being tracked by our `era-test-node` clone. We need to always copy our precompiles into the `era-test-node` repo for it to be able to track and compile them for later testing.
-
-```
-make build-precompiles
-```
 
 ### Run the tests
 


### PR DESCRIPTION
This improved makefile avoids a bug that didn't allow the user to run the node when the submodule folder was created.

It also improves the workflow, only one command is needed to use the project