### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ run-node: $(era_test_node) $(precompiles_dst)
 run-node-light: $(era_test_node) $(precompiles_dst)
 	$(era_test_node) run
 
-$(era_test_node): $(era_test_node_makefile)
+$(era_test_node): $(era_test_node_makefile) $(precompiles_dst)
 	cd $(era_test_node_base_path) && make rust-build
 	
 ## precompile source is added just to avoid recompiling if they haven't changed
@@ -26,7 +26,7 @@ build-precompiles: $(precompiles_dst)
 
 # Node Commands
 update-node: era_test_node
-	cd $(era_test_node_base_path) && git pull && make rust-build
+	cd $(era_test_node_base_path) && make rust-build
 
 test:
 	cd tests && \

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ era_test_node_base_path := $(current_dir)/.test-node-subtree
 era_test_node := $(era_test_node_base_path)/target/release/era_test_node
 era_test_node_makefile := $(era_test_node_base_path)/Makefile
 precompile_dst_path := $(era_test_node_base_path)/etc/system-contracts/contracts/precompiles
+era_test_node_src_files = $(shell find $(era_test_node_base_path)/src -name "*.rs")
 
 precompiles_source = $(wildcard $(current_dir)/precompiles/*.yul)
 precompiles_dst = $(patsubst $(current_dir)/precompiles/%, $(precompile_dst_path)/%, $(precompiles_source))
@@ -15,7 +16,10 @@ run-node: $(era_test_node) $(precompiles_dst)
 run-node-light: $(era_test_node) $(precompiles_dst)
 	$(era_test_node) run
 
-$(era_test_node): $(era_test_node_makefile) $(precompiles_dst)
+# test node needs contracts for include bytes directive
+# source files are obtained just to recompile if there are changes, and located with a find
+
+$(era_test_node): $(era_test_node_makefile) $(era_test_node_src_files) $(precompiles_dst)
 	cd $(era_test_node_base_path) && make rust-build
 	
 ## precompile source is added just to avoid recompiling if they haven't changed

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ run-node-light: $(era_test_node) $(precompiles_dst)
 
 # test node needs contracts for include bytes directive
 # source files are obtained just to recompile if there are changes, and located with a find
-
 $(era_test_node): $(era_test_node_makefile) $(era_test_node_src_files) $(precompiles_dst)
 	cd $(era_test_node_base_path) && make rust-build
 	


### PR DESCRIPTION
Small makefile fixes:

- Recompile the node automatically if the rust code changes
- Recompile contracts if they change before running the node (Before adding a new precompile would break the node, because it wouldn't find it)